### PR TITLE
Fix buildtype option passing problem (#12)

### DIFF
--- a/API/application/base.py
+++ b/API/application/base.py
@@ -25,6 +25,7 @@ class ApplicationBase(object):
         self.device = device
         self.branch = options.branch
         self.commit = options.commit
+        self.buildtype = options.buildtype
 
     def get_name(self):
         '''
@@ -86,7 +87,7 @@ class ApplicationBase(object):
         '''
         raise NotImplementedError('Use the concrete subclasses.')
 
-    def build(self, buildtype):
+    def build(self):
         '''
         Build the application.
         '''

--- a/API/application/iotjs.py
+++ b/API/application/iotjs.py
@@ -31,7 +31,7 @@ class Application(base.ApplicationBase):
         '''
         Return the path to the binary.
         '''
-        return utils.join(paths.IOTJS_BUILD_PATH, 'iotjs')
+        return utils.join(paths.IOTJS_BUILD_PATH, 'iotjs') % self.buildtype
 
     def get_home_dir(self):
         '''
@@ -43,7 +43,7 @@ class Application(base.ApplicationBase):
         '''
         Returns the sizes of the main sections.
         '''
-        iotjs_bin = utils.join(paths.IOTJS_MINIMAL_BIN_PATH, 'iotjs')
+        iotjs_bin = utils.join(paths.IOTJS_MINIMAL_BIN_PATH, 'iotjs') % self.buildtype
         utils.execute(paths.IOTJS_PATH, 'arm-linux-gnueabi-strip', [iotjs_bin])
         sections, exitcode = utils.execute(paths.IOTJS_PATH, 'arm-linux-gnueabi-size', ['-A', iotjs_bin], quiet=True)
 
@@ -113,7 +113,7 @@ class Application(base.ApplicationBase):
         utils.execute(paths.IOTJS_JERRY_PATH, 'git', ['apply', jerry_memstat_patch])
         utils.execute(paths.IOTJS_JERRY_PATH, 'git', ['add', '-u'])
 
-    def build(self, buildtype):
+    def build(self):
         '''
         Build IoT.js for the target device/OS and for Raspberry Pi 2.
         '''
@@ -124,7 +124,7 @@ class Application(base.ApplicationBase):
         # is based on this target.
         minimal_build_flags = [
             '--clean',
-            '--buildtype=release',
+            '--buildtype=%s' % self.buildtype,
             '--target-arch=arm',
             '--no-parallel-build',
             '--target-board=rpi2',
@@ -137,7 +137,7 @@ class Application(base.ApplicationBase):
         build_flags = [
             '--clean',
             '--target-arch=arm',
-            '--buildtype=%s' % buildtype,
+            '--buildtype=%s' % self.buildtype,
         ]
 
         if self.device.get_type() == 'stm32f4dis' and self.os == 'nuttx':

--- a/API/application/jerryscript.py
+++ b/API/application/jerryscript.py
@@ -96,7 +96,7 @@ class Application(base.ApplicationBase):
         utils.execute(paths.JERRY_PATH, 'git', ['pull', 'origin', self.branch])
         utils.execute(paths.JERRY_PATH, 'git', ['checkout', self.commit])
 
-    def build(self, buildtype):
+    def build(self):
         '''
         Build IoT.js for the target device/OS and for Raspberry Pi 2.
         '''

--- a/API/common/paths.py
+++ b/API/common/paths.py
@@ -78,7 +78,7 @@ IOTJS_PATH = os.path.join(PROJECTS_ROOT, 'iotjs')
 IOTJS_APPS_PATH = os.path.join(IOTJS_PATH, 'config/nuttx/stm32f4dis/app/')
 
 # Path to the build folder within iotjs.
-IOTJS_BUILD_PATH = os.path.join(IOTJS_PATH, 'build/arm-linux/release/bin')
+IOTJS_BUILD_PATH = os.path.join(IOTJS_PATH, 'build/arm-linux/%s/bin')
 
 # Root directory of the test folder.
 IOTJS_TEST_PATH = os.path.join(IOTJS_PATH, 'test')
@@ -87,7 +87,7 @@ IOTJS_TEST_PATH = os.path.join(IOTJS_PATH, 'test')
 IOTJS_MINIMAL_BUILD_PATH = os.path.join(IOTJS_PATH, 'features_disable/build')
 
 # Path to the bin folder of the minimal build.
-IOTJS_MINIMAL_BIN_PATH = os.path.join(IOTJS_MINIMAL_BUILD_PATH, 'arm-linux/release/bin/')
+IOTJS_MINIMAL_BIN_PATH = os.path.join(IOTJS_MINIMAL_BUILD_PATH, 'arm-linux/%s/bin/')
 
 # Path to the deps/libtuv folder.
 IOTJS_LIBTUV_PATH = os.path.join(IOTJS_PATH, 'deps/libtuv')

--- a/driver.py
+++ b/driver.py
@@ -84,7 +84,7 @@ def main():
     os = API.os.create(options.os, app)
     os.prebuild()
 
-    app.build(options.buildtype)
+    app.build()
     os.build(options.buildtype, 'all')
 
     device.flash(os)


### PR DESCRIPTION
I could build iotjs debug version, as the paths were static in the `paths.py` file